### PR TITLE
Add select & checkbox components

### DIFF
--- a/src/components/form/PPButton.vue
+++ b/src/components/form/PPButton.vue
@@ -4,11 +4,31 @@
 
 <style scoped>
 .ui-button {
+  display: inline-block;
   padding: var(--pp-gap-sm) var(--pp-gap-md);
   background: var(--pp-primary-color);
   color: var(--pp-primary-on-color);
+  border: 1px solid var(--pp-primary-color);
   border-radius: var(--pp-border-radius-sm);
   font-size: var(--pp-font-size-md);
-  border: none;
+  font-weight: var(--pp-font-weight-bold);
+  cursor: pointer;
+  text-align: center;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+
+.ui-button:hover {
+  background: var(--pp-primary-color-hover);
+  border-color: var(--pp-primary-color-hover);
+}
+
+.ui-button:active {
+  background: var(--pp-primary-color-active);
+  border-color: var(--pp-primary-color-active);
+}
+
+.ui-button:disabled {
+  opacity: var(--pp-disabled-opacity);
+  cursor: not-allowed;
 }
 </style>

--- a/src/components/form/inputs/PPCheckbox.vue
+++ b/src/components/form/inputs/PPCheckbox.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="checkbox-wrapper">
+    <label class="checkbox-container">
+      <input
+        type="checkbox"
+        class="checkbox-element"
+        :checked="modelValue"
+        @change="onChange"
+      />
+      <span class="checkbox-label">{{ label }}</span>
+    </label>
+    <div class="error-message">
+      <span v-if="hasError">{{ error }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps<{
+  modelValue: boolean;
+  label: string;
+  error?: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+}>();
+
+const hasError = computed(() => !!props.error);
+
+function onChange(event: Event) {
+  const target = event.target as HTMLInputElement;
+  emit('update:modelValue', target.checked);
+}
+</script>
+
+<style scoped>
+.checkbox-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.checkbox-container {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pp-gap-xs);
+  cursor: pointer;
+  user-select: none;
+}
+
+.checkbox-element {
+  width: var(--pp-font-size-md);
+  height: var(--pp-font-size-md);
+  margin: 0;
+  accent-color: var(--pp-primary-color);
+}
+
+.checkbox-label {
+  font-size: var(--pp-font-size-md);
+  color: var(--pp-text-color);
+}
+
+.error-message {
+  margin-top: var(--pp-gap-xs);
+  padding-left: var(--pp-gap-xs);
+  font-size: var(--pp-font-size-xs);
+  color: var(--pp-error-color);
+}
+</style>

--- a/src/components/form/inputs/PPSelect.vue
+++ b/src/components/form/inputs/PPSelect.vue
@@ -1,0 +1,104 @@
+<template>
+  <div class="select-wrapper">
+    <div :class="['select-container', { 'has-error': hasError }]">
+      <label :for="id" :class="['floating-label', { active: isFocused || modelValue }]">
+        {{ label }}
+      </label>
+      <select
+        :id="id"
+        class="select-element"
+        :value="modelValue"
+        @input="onInput"
+        @focus="isFocused = true"
+        @blur="isFocused = false"
+      >
+        <slot />
+      </select>
+    </div>
+    <div class="error-message">
+      <span v-if="hasError">{{ error }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+
+const props = defineProps<{
+  modelValue: string | number;
+  label: string;
+  error?: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string | number): void;
+}>();
+
+const id = `select-${Math.random().toString(36).substring(2, 10)}`;
+const isFocused = ref(false);
+const hasError = computed(() => !!props.error);
+
+function onInput(event: Event) {
+  const target = event.target as HTMLSelectElement;
+  emit('update:modelValue', target.value);
+}
+</script>
+
+<style scoped>
+.select-wrapper {
+  width: 100%;
+  display: flex;
+}
+
+.select-container {
+  width: 100%;
+  position: relative;
+  border: 1px solid var(--pp-secondary-light-color);
+  background-color: transparent;
+  border-radius: var(--pp-border-radius-md);
+  padding: var(--pp-gap-md) var(--pp-gap-md) var(--pp-gap-sm) var(--pp-gap-md);
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+.select-container.has-error {
+  border-color: var(--pp-error-color);
+  background-color: var(--pp-error-light-color);
+}
+
+.select-container.has-error .floating-label {
+  color: var(--pp-error-color);
+}
+
+.select-element {
+  width: 100%;
+  border: none;
+  outline: none;
+  padding: 0;
+  background: transparent;
+  font-size: var(--pp-font-size-md);
+  color: var(--pp-text-color);
+  appearance: none;
+}
+
+.floating-label {
+  position: absolute;
+  top: calc(var(--pp-gap-md) - var(--pp-gap-sm) / 2);
+  left: var(--pp-gap-md);
+  font-size: var(--pp-font-size-md);
+  color: var(--pp-secondary-color);
+  pointer-events: none;
+  transition: 0.2s ease all;
+}
+
+.floating-label.active {
+  top: calc(var(--pp-gap-sm) / 5);
+  font-size: var(--pp-font-size-xs);
+}
+
+.error-message {
+  margin-top: var(--pp-gap-xs);
+  padding-left: var(--pp-gap-xs);
+  font-size: var(--pp-font-size-xs);
+  color: var(--pp-error-color);
+}
+</style>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,7 @@
 export { default as PPButton } from './form/PPButton.vue';
 export { default as PPInput } from './form/inputs/PPInput.vue';
+export { default as PPSelect } from './form/inputs/PPSelect.vue';
+export { default as PPCheckbox } from './form/inputs/PPCheckbox.vue';
 export { default as PPAccordion } from './list/Accordion/PPAccordion.vue';
 export { default as PPAccordionItem } from './list/Accordion/PPAccordionItem.vue';
 export { default as PPGrid } from './layout/PPGrid.vue';

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -33,4 +33,9 @@
   --pp-border-radius-lg: 1rem;
   --pp-border-radius-xl: 2rem;
 
+  /* Button */
+  --pp-primary-color-hover: #0069d9;
+  --pp-primary-color-active: #005cbf;
+  --pp-disabled-opacity: 0.65;
+
 }


### PR DESCRIPTION
## Summary
- add `PPSelect` and `PPCheckbox` components
- improve `PPButton` styling and expose more CSS vars
- export new components
- update variables with button-related colors
- add error support to `PPCheckbox`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870ee1fbfec8329978f776c650f39f1